### PR TITLE
change members carousel behavior

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -174,3 +174,13 @@ div {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
 }
+
+.scrollbar-hide {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+


### PR DESCRIPTION
The members section on the homepage was previously showing an error during the auto-slide behavior.
To resolve this, the logic was reworked: it now features an infinite continuous scroll on desktop and a simple horizontal scroll on mobile breakpoints.

Tested locally. Ready for production!